### PR TITLE
Fix PT banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Paper Trails is an interactive browser-based timeline of scientific history. It places scientists and their publications alongside major discoveries and wider historical events, making it easier to see how scientific ideas developed in context from 1600 to the present year.
 
-The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 56 scientists, 90 publications, 14 discoveries, and 15 historical events.
+The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 61 scientists, 104 publications, 14 discoveries, and 15 historical events.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Paper Trails is an interactive browser-based timeline of scientific history. It places scientists and their publications alongside major discoveries and wider historical events, making it easier to see how scientific ideas developed in context from 1600 to the present year.
 
-The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 61 scientists, 104 publications, 14 discoveries, and 15 historical events.
+The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 56 scientists, 90 publications, 14 discoveries, and 15 historical events.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <header class="app-header">
     <div class="brand">
-      <div class="brand-mark" aria-hidden="true">PT</div>
+      <img class="brand-mark" src="images/icon.png" alt="" width="38" height="38" aria-hidden="true">
       <div>
         <h1>Paper Trails</h1>
         <p>Scientific ideas in historical context · <span id="timeline-range">1600–today</span></p>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <body>
   <header class="app-header">
     <div class="brand">
-      <img class="brand-mark" src="images/icon.png" alt="" width="38" height="38" aria-hidden="true">
+      <img class="brand-mark" src="images/icon_trans.png" alt="" width="38" height="38" aria-hidden="true">
       <div>
         <h1>Paper Trails</h1>
         <p>Scientific ideas in historical context · <span id="timeline-range">1600–today</span></p>

--- a/style.css
+++ b/style.css
@@ -138,15 +138,9 @@ input:focus-visible,
   height: 38px;
   flex: 0 0 auto;
   border-radius: 10px;
-  background: linear-gradient(145deg, var(--accent), #5946c8);
   box-shadow: var(--shadow-sm);
-  color: #fff;
-  display: grid;
-  place-items: center;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
+  display: block;
+  object-fit: cover;
 }
 
 .brand h1 {


### PR DESCRIPTION
## Summary

- Replace the text-based PT banner with the Paper Trails icon.
- Update banner styling to display the image correctly.
- Refresh README dataset counts.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the header brand mark with a new image-based design.
  * Improved image sizing and display for a cleaner, more consistent appearance.
  * Preserved the existing shadow effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->