### PR TITLE
Enhance scientist detail cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ A scientist entry has this shape:
 ```yaml
 example_id:
   name: "Example Scientist"
+  summary: "A concise explanation of why this person and their work matter."
   color: "#336699"
   photo: "images/example.jpg"
   cartoon: "images/cartoons/example.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1900-01-01"
   death: "1980-01-01"
   publications:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Paper Trails is an interactive browser-based timeline of scientific history. It places scientists and their publications alongside major discoveries and wider historical events, making it easier to see how scientific ideas developed in context from 1600 to the present year.
 
-The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 61 scientists, 104 publications, 14 discoveries, and 15 historical events.
+The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 56 scientists, 90 publications, 14 discoveries, and 15 historical events.
 
 ## Features
 

--- a/data/scientists.yaml
+++ b/data/scientists.yaml
@@ -38,6 +38,7 @@ huygens:
 
 newton:
   name: "Isaac Newton"
+  summary: "A central figure in the Scientific Revolution whose work established classical mechanics and transformed the study of light."
   color: "#e63946"
   photo: "images/newton.jpg"
   cartoon: "images/cartoons/newton.png"
@@ -154,7 +155,7 @@ young:
   color: "#4cc9f0"
   photo: "images/young.jpg"
   cartoon: "images/cartoons/young.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1773-06-13"
   death: "1829-05-10"
   publications:
@@ -399,7 +400,7 @@ thomson:
   color: "#900c3f"
   photo: "images/thomson.jpg"
   cartoon: "images/cartoons/thomson.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1856-12-18"
   death: "1940-08-30"
   publications:
@@ -438,7 +439,7 @@ rutherford:
   color: "#c1121f"
   photo: "images/rutherford.jpg"
   cartoon: "images/cartoons/rutherford.png"
-  nationality: "New Zealand/British"
+  nationality: "New Zealander"
   birth: "1871-08-30"
   death: "1937-10-19"
   publications:
@@ -454,7 +455,7 @@ h_a_wilson:
   color: "#6c757d"
   photo: "images/wilson.jpg"
   cartoon: "images/cartoons/wilson.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1874-12-01"
   death: "1964-10-13"
   publications:
@@ -544,7 +545,7 @@ chadwick:
   color: "#ef476f"
   photo: "images/chadwick.jpg"
   cartoon: "images/cartoons/chadwick.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1891-10-20"
   death: "1974-07-24"
   publications:
@@ -628,7 +629,7 @@ dirac:
   color: "#007f5f"
   photo: "images/dirac.jpg"
   cartoon: "images/cartoons/dirac.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1902-08-08"
   death: "1984-10-20"
   publications:
@@ -699,7 +700,7 @@ hoyle:
   color: "#ff6b6b" # Reddish
   photo: "images/hoyle.jpg"
   cartoon: "images/cartoons/hoyle.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1915-06-24"
   death: "2001-08-20"
   publications:
@@ -715,7 +716,7 @@ sciama:
   color: "#6a0dad" # Purple
   photo: "images/sciama.jpg"
   cartoon: "images/cartoons/sciama.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1926-11-18"
   death: "1999-12-19"
   publications:
@@ -814,7 +815,7 @@ eddington:
   color: "#ca6702"
   photo: "images/eddington.jpg"
   cartoon: "images/cartoons/eddington.png"
-  nationality: "British"
+  nationality: "English"
   birth: "1882-12-28"
   death: "1944-11-22"
   publications:
@@ -887,7 +888,7 @@ kelvin:
   color: "#5f0f40"
   photo: "images/kelvin.jpg"
   cartoon: "images/cartoons/kelvin.png"
-  nationality: "British"
+  nationality: "Irish"
   birth: "1824-06-26"
   death: "1907-12-17"
   publications:

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Explore scientific publications, discoveries, and their historical context from 1600 to today.">
   <title>Paper Trails — Scientific History</title>
   <link rel="icon" href="images/icon.png" type="image/png">
-  <link rel="stylesheet" href="style.css?v=7">
+  <link rel="stylesheet" href="style.css?v=8">
 </head>
 <body>
   <header class="app-header">
@@ -123,19 +123,24 @@
     <button class="detail-close icon-button" id="detail-close" type="button" aria-label="Close details">
       <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6 6 18"></path></svg>
     </button>
-    <div class="detail-media" id="detail-media" hidden>
-      <img id="detail-image" alt="">
+    <div class="detail-header">
+      <div class="detail-media" id="detail-media" hidden>
+        <img id="detail-image" alt="">
+      </div>
+      <div class="detail-heading">
+        <p class="detail-eyebrow" id="detail-eyebrow">Publication</p>
+        <h2 id="detail-title" tabindex="-1">Details</h2>
+        <p class="detail-identity" id="detail-identity" hidden></p>
+      </div>
     </div>
-    <p class="detail-eyebrow" id="detail-eyebrow">Publication</p>
-    <h2 id="detail-title">Details</h2>
     <dl class="detail-metadata" id="detail-metadata"></dl>
     <div class="detail-divider"></div>
-    <p class="detail-body" id="detail-body"></p>
+    <div class="detail-body" id="detail-body"></div>
   </aside>
 
   <div class="timeline-tooltip" id="timeline-tooltip" role="tooltip" hidden></div>
 
   <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
-  <script type="module" src="script.js?v=7"></script>
+  <script type="module" src="script.js?v=8"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
-import { config } from './src/config.js?v=7';
-import { initializeData } from './src/dataLoader.js?v=7';
-import { initializeTheme } from './src/themeManager.js?v=7';
-import { setupModalEventListeners } from './src/modalManager.js?v=7';
-import { clearTimelineSelection, renderTimeline } from './src/timelineRenderer.js?v=7';
+import { config } from './src/config.js?v=8';
+import { initializeData } from './src/dataLoader.js?v=8';
+import { initializeTheme } from './src/themeManager.js?v=8';
+import { setupModalEventListeners } from './src/modalManager.js?v=8';
+import { clearTimelineSelection, renderTimeline } from './src/timelineRenderer.js?v=8';
 
 let timelineContainer;
 let timeline;
@@ -113,6 +113,23 @@ function focusYear(year, scale = 2.5) {
   currentTranslateX = timelineContainer.clientWidth / 2 - targetX;
   updateTransform();
   hideInteractionHint();
+}
+
+function focusScientist(scientistId, year) {
+  if (!scientistId || !Number.isFinite(year)) return;
+
+  const peopleToggle = document.getElementById('peopleToggle');
+  if (peopleToggle?.getAttribute('aria-pressed') === 'false') {
+    peopleToggle.setAttribute('aria-pressed', 'true');
+  }
+
+  focusYear(year);
+  const node = timeline.querySelector(`.scientist-node[data-scientist-id="${CSS.escape(scientistId)}"]`);
+  if (!node) return;
+
+  clearTimelineSelection();
+  node.classList.add('is-selected');
+  node.focus({ preventScroll: true });
 }
 
 function togglePressed(button) {
@@ -345,6 +362,9 @@ async function initializeApp() {
     setupResizeHandler();
     document.addEventListener('papertrails:detailsclosed', clearTimelineSelection);
     document.addEventListener('papertrails:zoomcluster', (event) => focusYear(event.detail.year));
+    document.addEventListener('papertrails:locatescientist', (event) => {
+      focusScientist(event.detail.scientistId, event.detail.year);
+    });
     hideInteractionHint(6500);
   } catch (error) {
     console.error('Paper Trails failed to initialize:', error);

--- a/src/modalManager.js
+++ b/src/modalManager.js
@@ -1,10 +1,11 @@
-import { scientists } from './dataLoader.js?v=7';
+import { scientists } from './dataLoader.js?v=8';
 
 let panel;
 let backdrop;
 let closeButton;
 let eyebrow;
 let title;
+let identity;
 let metadata;
 let body;
 let media;
@@ -18,12 +19,13 @@ function fetchElements() {
   closeButton = document.getElementById('detail-close');
   eyebrow = document.getElementById('detail-eyebrow');
   title = document.getElementById('detail-title');
+  identity = document.getElementById('detail-identity');
   metadata = document.getElementById('detail-metadata');
   body = document.getElementById('detail-body');
   media = document.getElementById('detail-media');
   image = document.getElementById('detail-image');
 
-  return Boolean(panel && backdrop && closeButton && eyebrow && title && metadata && body && media && image);
+  return Boolean(panel && backdrop && closeButton && eyebrow && title && identity && metadata && body && media && image);
 }
 
 function renderMetadata(items) {
@@ -45,7 +47,9 @@ function openPanel() {
     closeTimer = null;
   }
 
-  lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (panel.hidden) {
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }
   panel.hidden = false;
   backdrop.hidden = false;
 
@@ -54,6 +58,152 @@ function openPanel() {
     backdrop.classList.add('is-open');
     closeButton.focus({ preventScroll: true });
   });
+}
+
+function formatYear(date) {
+  const year = Number.parseInt(String(date || '').slice(0, 4), 10);
+  return Number.isFinite(year) ? String(year) : null;
+}
+
+function calculateAge(birth, death) {
+  const birthMatch = String(birth || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  const deathMatch = String(death || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!birthMatch || !deathMatch) return null;
+
+  let age = Number(deathMatch[1]) - Number(birthMatch[1]);
+  const birthMonthDay = `${birthMatch[2]}-${birthMatch[3]}`;
+  const deathMonthDay = `${deathMatch[2]}-${deathMatch[3]}`;
+  if (deathMonthDay < birthMonthDay) age -= 1;
+  return age >= 0 ? age : null;
+}
+
+function getIdentityLine(scientist) {
+  const birthYear = formatYear(scientist.birth);
+  const deathYear = formatYear(scientist.death);
+  const age = calculateAge(scientist.birth, scientist.death);
+  const lifespan = birthYear && deathYear ? `${birthYear}–${deathYear}` : birthYear ? `Born ${birthYear}` : null;
+  return [scientist.nationality, lifespan, age !== null ? `aged ${age}` : null].filter(Boolean).join(' · ');
+}
+
+function getScientistSummary(scientist) {
+  return scientist.summary
+    || scientist.details
+    || scientist.publications?.find((publication) => publication.abstract)?.abstract
+    || 'No biographical summary is available yet.';
+}
+
+function createPublicationList(scientist) {
+  const section = document.createElement('section');
+  section.className = 'detail-publications';
+
+  const headingRow = document.createElement('div');
+  headingRow.className = 'detail-section-heading';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Publications on this timeline';
+
+  const count = document.createElement('span');
+  count.className = 'detail-section-count';
+  count.textContent = String(scientist.publications?.length || 0);
+  count.setAttribute('aria-label', `${count.textContent} publications`);
+  headingRow.append(heading, count);
+  section.appendChild(headingRow);
+
+  const list = document.createElement('ul');
+  list.className = 'detail-publication-list';
+
+  [...(scientist.publications || [])]
+    .sort((a, b) => (a.year || 0) - (b.year || 0))
+    .forEach((publication) => {
+      const item = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'detail-publication-link';
+      button.setAttribute('aria-label', `Open ${publication.title || 'untitled publication'}, ${publication.year || 'year not recorded'}`);
+
+      const year = document.createElement('span');
+      year.className = 'detail-publication-year';
+      year.textContent = publication.year || '—';
+
+      const content = document.createElement('span');
+      content.className = 'detail-publication-content';
+
+      const publicationTitle = document.createElement('span');
+      publicationTitle.className = 'detail-publication-title';
+      publicationTitle.textContent = publication.title || 'Untitled publication';
+      content.appendChild(publicationTitle);
+
+      if (publication.abstract) {
+        const abstract = document.createElement('span');
+        abstract.className = 'detail-publication-abstract';
+        abstract.textContent = publication.abstract;
+        content.appendChild(abstract);
+      }
+
+      const arrow = document.createElement('span');
+      arrow.className = 'detail-publication-arrow';
+      arrow.setAttribute('aria-hidden', 'true');
+      arrow.textContent = '→';
+
+      button.append(year, content, arrow);
+      button.addEventListener('click', () => {
+        showPublicationModal(scientist.name, publication.year, publication.title, publication.abstract, 'publication');
+      });
+      item.appendChild(button);
+      list.appendChild(item);
+    });
+
+  if (list.children.length) {
+    section.appendChild(list);
+  } else {
+    const emptyState = document.createElement('p');
+    emptyState.className = 'detail-empty-state';
+    emptyState.textContent = 'No publications are represented on this timeline yet.';
+    section.appendChild(emptyState);
+  }
+
+  return section;
+}
+
+function createLocateAction(scientistId, scientist) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'detail-locate-action';
+
+  const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  icon.setAttribute('class', 'detail-locate-icon');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.setAttribute('viewBox', '0 0 24 24');
+
+  const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  circle.setAttribute('cx', '12');
+  circle.setAttribute('cy', '12');
+  circle.setAttribute('r', '3');
+
+  const crosshairs = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  crosshairs.setAttribute('d', 'M12 2v4M12 18v4M2 12h4M18 12h4');
+  icon.append(circle, crosshairs);
+
+  const label = document.createElement('span');
+  label.textContent = `Locate ${scientist.name || 'scientist'} on timeline`;
+  button.append(icon, label);
+
+  button.addEventListener('click', () => {
+    const firstPublication = [...(scientist.publications || [])]
+      .filter((publication) => Number.isFinite(publication.year))
+      .sort((a, b) => a.year - b.year)[0];
+
+    closeModal({
+      restoreFocus: false,
+      afterClose: () => {
+        document.dispatchEvent(new CustomEvent('papertrails:locatescientist', {
+          detail: { scientistId, year: firstPublication?.year }
+        }));
+      }
+    });
+  });
+
+  return button;
 }
 
 export function showPublicationModal(actorName, itemYear, itemTitle, description, type = 'publication') {
@@ -67,8 +217,15 @@ export function showPublicationModal(actorName, itemYear, itemTitle, description
 
   eyebrow.textContent = typeLabels[type] || 'Timeline item';
   title.textContent = itemTitle || 'Untitled item';
-  body.textContent = description || 'No further details are available.';
+  identity.hidden = true;
+  identity.textContent = '';
+  body.replaceChildren();
+  const descriptionText = document.createElement('p');
+  descriptionText.className = 'detail-copy';
+  descriptionText.textContent = description || 'No further details are available.';
+  body.appendChild(descriptionText);
   media.hidden = true;
+  metadata.hidden = false;
 
   if (type === 'event') {
     renderMetadata([['Period', itemYear]]);
@@ -88,21 +245,25 @@ export function showScientistModal(scientistId) {
 
   eyebrow.textContent = 'Scientist';
   title.textContent = scientist.name || 'Unknown scientist';
-  renderMetadata([
-    ['Nationality', scientist.nationality],
-    ['Born', scientist.birth],
-    ['Died', scientist.death]
-  ]);
+  identity.textContent = getIdentityLine(scientist);
+  identity.hidden = !identity.textContent;
+  metadata.replaceChildren();
+  metadata.hidden = true;
 
-  const publicationCount = scientist.publications?.length || 0;
-  body.textContent = scientist.details || `${publicationCount} ${publicationCount === 1 ? 'publication is' : 'publications are'} represented on this timeline.`;
+  const summary = document.createElement('p');
+  summary.className = 'detail-summary';
+  summary.textContent = getScientistSummary(scientist);
+
+  const locateAction = createLocateAction(scientistId, scientist);
+  body.replaceChildren(summary, createPublicationList(scientist), locateAction);
   image.src = scientist.photo || 'images/default.png';
   image.alt = scientist.name ? `Portrait of ${scientist.name}` : 'Scientist portrait';
+  media.style.setProperty('--scientist-color', scientist.color || 'var(--accent)');
   media.hidden = false;
   openPanel();
 }
 
-export function closeModal() {
+export function closeModal({ restoreFocus = true, afterClose = null } = {}) {
   if (!panel || panel.hidden || closeTimer) return;
 
   panel.classList.remove('is-open');
@@ -111,10 +272,17 @@ export function closeModal() {
     panel.hidden = true;
     backdrop.hidden = true;
     closeTimer = null;
+    if (typeof afterClose === 'function') afterClose();
   }, 230);
 
   document.dispatchEvent(new CustomEvent('papertrails:detailsclosed'));
-  lastFocusedElement?.focus({ preventScroll: true });
+  if (restoreFocus) lastFocusedElement?.focus({ preventScroll: true });
+}
+
+function getFocusableElements() {
+  if (!panel) return [];
+  return [...panel.querySelectorAll('button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')]
+    .filter((element) => !element.hidden && element.getClientRects().length > 0);
 }
 
 export function setupModalEventListeners() {
@@ -126,10 +294,26 @@ export function setupModalEventListeners() {
   closeButton.addEventListener('click', closeModal);
   backdrop.addEventListener('click', closeModal);
   window.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') closeModal();
+    if (event.key === 'Escape') {
+      closeModal();
+      return;
+    }
     if (event.key === 'Tab' && !panel.hidden) {
-      event.preventDefault();
-      closeButton.focus();
+      const focusableElements = getFocusableElements();
+      if (!focusableElements.length) return;
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!panel.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
     }
   });
 }

--- a/src/themeManager.js
+++ b/src/themeManager.js
@@ -1,4 +1,4 @@
-import { config } from './config.js?v=7';
+import { config } from './config.js?v=8';
 
 let modeToggleButton;
 

--- a/src/timelineRenderer.js
+++ b/src/timelineRenderer.js
@@ -1,7 +1,7 @@
-import { config } from './config.js?v=7';
-import { scientists, discoveries, significantEvents } from './dataLoader.js?v=7';
-import { showPublicationModal, showScientistModal } from './modalManager.js?v=7';
-import { handleImageError } from './themeManager.js?v=7';
+import { config } from './config.js?v=8';
+import { scientists, discoveries, significantEvents } from './dataLoader.js?v=8';
+import { showPublicationModal, showScientistModal } from './modalManager.js?v=8';
+import { handleImageError } from './themeManager.js?v=8';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 

--- a/style.css
+++ b/style.css
@@ -16,6 +16,7 @@
   --accent: #2563eb;
   --accent-hover: #1d4ed8;
   --accent-soft: #e8f0ff;
+  --on-accent: #ffffff;
   --publication: #64748b;
   --discovery: #7c3aed;
   --discovery-soft: #ede9fe;
@@ -49,6 +50,7 @@ body.dark-mode {
   --accent: #6ea2ff;
   --accent-hover: #8bb5ff;
   --accent-soft: #1d3154;
+  --on-accent: #0b1220;
   --publication: #a4b2c5;
   --discovery: #a78bfa;
   --discovery-soft: #302650;
@@ -879,14 +881,25 @@ body.dark-mode .icon-sun {
   border-color: var(--border);
 }
 
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.detail-heading {
+  min-width: 0;
+}
+
 .detail-media {
-  width: 82px;
-  height: 82px;
-  margin-bottom: 22px;
+  width: 92px;
+  height: 92px;
+  flex: 0 0 auto;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: 2px solid color-mix(in srgb, var(--scientist-color) 62%, var(--border));
   border-radius: 50%;
   background: var(--surface-muted);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--scientist-color) 10%, transparent);
 }
 
 .detail-media img {
@@ -911,6 +924,17 @@ body.dark-mode .icon-sun {
   font-size: clamp(24px, 3vw, 30px);
   line-height: 1.16;
   letter-spacing: -0.025em;
+}
+
+.detail-panel h2:focus {
+  outline: none;
+}
+
+.detail-identity {
+  margin: 9px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
 }
 
 .detail-metadata {
@@ -942,6 +966,173 @@ body.dark-mode .icon-sun {
   color: var(--text-secondary);
   font-size: 15px;
   line-height: 1.7;
+}
+
+.detail-copy,
+.detail-summary,
+.detail-empty-state {
+  margin: 0;
+}
+
+.detail-summary {
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.65;
+}
+
+.detail-publications {
+  margin-top: 30px;
+}
+
+.detail-section-heading {
+  margin-bottom: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-section-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.085em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.detail-section-count {
+  min-width: 25px;
+  height: 25px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 25px;
+  text-align: center;
+}
+
+.detail-publication-list {
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+
+.detail-publication-list li {
+  border-bottom: 1px solid var(--border);
+}
+
+.detail-publication-link {
+  width: 100%;
+  padding: 15px 6px 15px 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) 18px;
+  align-items: start;
+  gap: 10px;
+  text-align: left;
+  transition: background-color 140ms ease, color 140ms ease, padding 140ms ease;
+}
+
+.detail-publication-link:hover {
+  padding-left: 8px;
+  background: var(--surface-muted);
+}
+
+.detail-publication-year {
+  padding-top: 1px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+}
+
+.detail-publication-content {
+  min-width: 0;
+  display: block;
+}
+
+.detail-publication-title,
+.detail-publication-abstract {
+  display: block;
+}
+
+.detail-publication-title {
+  color: var(--text-primary);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.detail-publication-abstract {
+  margin-top: 5px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.detail-publication-arrow {
+  padding-top: 1px;
+  color: var(--text-tertiary);
+  font-size: 17px;
+  line-height: 1;
+  transition: color 140ms ease, transform 140ms ease;
+}
+
+.detail-publication-link:hover .detail-publication-arrow {
+  color: var(--accent);
+  transform: translateX(2px);
+}
+
+.detail-empty-state {
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.detail-locate-action {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 14px;
+  margin-top: 24px;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--on-accent);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  font-weight: 700;
+  transition: background-color 140ms ease, border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.detail-locate-action:hover {
+  border-color: var(--accent-hover);
+  background: var(--accent-hover);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.detail-locate-icon {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
 }
 
 @media (max-width: 980px) {
@@ -1118,14 +1309,30 @@ body.dark-mode .icon-sun {
   }
 
   .detail-media {
-    width: 68px;
-    height: 68px;
-    margin-bottom: 16px;
+    width: 72px;
+    height: 72px;
+  }
+
+  .detail-header {
+    gap: 14px;
   }
 
   .detail-panel h2 {
     padding-right: 30px;
     font-size: 24px;
+  }
+
+  .detail-divider {
+    margin: 22px 0 18px;
+  }
+
+  .detail-publications {
+    margin-top: 24px;
+  }
+
+  .detail-publication-link {
+    grid-template-columns: 42px minmax(0, 1fr) 16px;
+    gap: 8px;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1129,7 +1129,7 @@ body.dark-mode .icon-sun {
   width: 17px;
   height: 17px;
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 1.8;


### PR DESCRIPTION
## Summary
- Add richer scientist detail cards with summaries, portraits, publication lists, and metadata.
- Add publication navigation and a locate-on-timeline action.
- Improve modal accessibility, focus handling, responsive styling, and theme support.
- Remove five scientist records and associated images; update dataset counts and nationality labels.
- Bump asset version parameters and fix the PT banner.

## Testing
- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scientist details now include lifespans, ages, nationalities, summaries, publications, and timeline navigation.
  - Locate actions focus the timeline on a scientist’s year and highlight the matching entry.
  - Detail panels provide improved keyboard navigation and focus restoration.

- **Bug Fixes**
  - Invalid navigation targets are handled safely.
  - Publication content and empty states display more clearly.

- **Style**
  - Refreshed branding, detail-panel layout, responsive behavior, media presentation, and theme contrast.

- **Data Updates**
  - Added Newton’s summary and refined nationality information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->