### PR TITLE
Fix timeline labels at the first and last years

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Explore scientific publications, discoveries, and their historical context from 1600 to today.">
   <title>Paper Trails — Scientific History</title>
   <link rel="icon" href="images/icon.png" type="image/png">
-  <link rel="stylesheet" href="style.css?v=10">
+  <link rel="stylesheet" href="style.css?v=11">
 </head>
 <body>
   <header class="app-header">
@@ -141,6 +141,6 @@
   <div class="timeline-tooltip" id="timeline-tooltip" role="tooltip" hidden></div>
 
   <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
-  <script type="module" src="script.js?v=10"></script>
+  <script type="module" src="script.js?v=11"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ import { config } from './src/config.js?v=10';
 import { initializeData } from './src/dataLoader.js?v=10';
 import { initializeTheme } from './src/themeManager.js?v=10';
 import { setupModalEventListeners } from './src/modalManager.js?v=10';
-import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=10';
+import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=11';
 
 let timelineContainer;
 let timeline;

--- a/src/timelineRenderer.js
+++ b/src/timelineRenderer.js
@@ -66,6 +66,8 @@ function renderAxis(timeline, svg, width, height, axisY) {
     if (isHalfCentury) classes.push('tick-half-century');
     if (isCentury) classes.push('tick-century');
     if (isCurrent) classes.push('tick-current');
+    if (year === config.START_YEAR) classes.push('tick-start');
+    if (year === config.END_YEAR) classes.push('tick-end');
 
     const marker = document.createElement('div');
     marker.className = `year-marker ${classes.join(' ')}`;

--- a/style.css
+++ b/style.css
@@ -550,6 +550,16 @@ body.dark-mode .icon-sun {
   color: var(--accent);
 }
 
+.year-label.tick-start {
+  transform: none;
+  transform-origin: top left;
+}
+
+.year-label.tick-end {
+  transform: translateX(-100%);
+  transform-origin: top right;
+}
+
 .timeline[data-zoom-tier="overview"] .tick-decade:not(.tick-century):not(.tick-current),
 .timeline[data-zoom-tier="standard"] .tick-decade:not(.tick-half-century):not(.tick-century):not(.tick-current) {
   display: none;


### PR DESCRIPTION
## Summary
- Align the first timeline label to the left edge.
- Align the last timeline label to the right edge.
- Update asset version parameters for the timeline changes.

## Testing
- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timeline boundary labels so the first and last year align cleanly with the timeline edges.

* **Bug Fixes**
  * Corrected positioning of timeline axis markers and labels at the start and end years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->