### PR TITLE
Link conference and event attendees to timeline scientists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Paper Trails is an interactive browser-based timeline of scientific history. It places scientists and their publications alongside major discoveries and wider historical events, making it easier to see how scientific ideas developed in context from 1600 to the present year.
 
-The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 86 scientists, 153 publications, 14 discoveries, and 15 historical events.
+The included dataset focuses mainly on physics, astronomy, mathematics, and related subjects. It currently contains 86 scientists, 153 publications, 13 discoveries, 6 conference milestones, and 15 historical events.
 
 ## Features
 
@@ -70,7 +70,7 @@ example_id:
       abstract: "A short description of the work."
 ```
 
-Discovery entries use `year`, `title`, `discoverer`, `details`, `particle`, and `color`. Historical event entries use `title`, `shortTitle`, `startYear`, `endYear`, `details`, and `color`. `shortTitle` is the compact timeline label used when the full event title does not fit its duration band; use a familiar abbreviation where one exists, or a short recognisable name otherwise.
+Discovery entries use `year`, `title`, `discoverer`, `details`, `particle`, and `color`. Conference milestones in that file use `type: conference` instead of `discoverer` and can include `attendee_ids`, containing scientist keys from `data/scientists.yaml`; their detail cards list those attendees with links to their timeline nodes. Historical event entries use `title`, `shortTitle`, `startYear`, `endYear`, `details`, and `color`, and can also use `attendee_ids`. `shortTitle` is the compact timeline label used when the full event title does not fit its duration band; use a familiar abbreviation where one exists, or a short recognisable name otherwise.
 
 Place portrait files under `images/` and cartoon variants under `images/cartoons/`. Missing scientist portraits fall back to a theme-appropriate default image.
 

--- a/data/discoveries.yaml
+++ b/data/discoveries.yaml
@@ -101,9 +101,50 @@
   particle: γγ
   color: "#2ecc71" # Emerald green
 
+- year: 1881
+  title: "First International Electrical Congress"
+  type: conference
+  attendee_ids: [hippolyte_fizeau, gustav_kirchhoff, mach, kelvin]
+  details: "Held in Paris alongside the International Exposition of Electricity, the congress helped establish an internationally consistent system of practical electrical units, including the ohm, volt, ampere, coulomb, and farad."
+  particle: Ω
+  color: "#8A2BE2" # BlueViolet
+
+- year: 1911
+  title: "First Solvay Conference"
+  type: conference
+  attendee_ids: [einstein, lorentz, nernst, planck, poincare, rutherford]
+  details: "The first Solvay Conference, devoted to radiation and the quanta, brought leading physicists together to confront the conflict between classical physics and the emerging quantum ideas of Planck and Einstein."
+  particle: Ⅰ
+  color: "#8A2BE2" # BlueViolet
+
 - year: 1927
   title: "Fifth Solvay International Conference"
-  discoverer: "Solvay Conference"
+  type: conference
+  attendee_ids: [bohr, compton, deBroglie, dirac, einstein, heisenberg, lorentz, pauli, planck, schrodinger]
   details: "The fifth Solvay International Conference on Electrons and Photons, where many of the world's most notable physicists met to discuss the newly formulated quantum theory. Key discussions on wave-particle duality and the uncertainty principle took place."
   particle: ⑤
+  color: "#8A2BE2" # BlueViolet
+
+- year: 1933
+  title: "Seventh Solvay Conference"
+  type: conference
+  attendee_ids: [bohr, chadwick, deBroglie, dirac, heisenberg, pauli, rutherford, schrodinger]
+  details: "Devoted to the structure and properties of atomic nuclei, the seventh Solvay Conference brought together the rapidly developing evidence for neutrons, positrons, nuclear transformations, and new models of the nucleus."
+  particle: Ⅶ
+  color: "#8A2BE2" # BlueViolet
+
+- year: 1947
+  title: "Shelter Island Conference"
+  type: conference
+  attendee_ids: [feynman, lamb]
+  details: "A pivotal post-war meeting on quantum electrodynamics where Willis Lamb reported the Lamb shift. The discussions helped spur the calculations and renormalization methods that made modern QED a consistent predictive theory."
+  particle: QED
+  color: "#8A2BE2" # BlueViolet
+
+- year: 1957
+  title: "Chapel Hill Conference on Gravitation"
+  type: conference
+  attendee_ids: [dicke, feynman, sciama]
+  details: "The conference examined experimental tests of general relativity, gravitational radiation, cosmology, and the quantization of gravity. Feynman's arguments there helped clarify that gravitational waves carry physically measurable energy."
+  particle: GR
   color: "#8A2BE2" # BlueViolet

--- a/index.html
+++ b/index.html
@@ -141,6 +141,6 @@
   <div class="timeline-tooltip" id="timeline-tooltip" role="tooltip" hidden></div>
 
   <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
-  <script type="module" src="script.js?v=11"></script>
+  <script type="module" src="script.js?v=13"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ import { config } from './src/config.js?v=10';
 import { initializeData } from './src/dataLoader.js?v=10';
 import { initializeTheme } from './src/themeManager.js?v=10';
 import { setupModalEventListeners } from './src/modalManager.js?v=10';
-import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=11';
+import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=13';
 
 let timelineContainer;
 let timeline;

--- a/src/modalManager.js
+++ b/src/modalManager.js
@@ -43,7 +43,24 @@ function renderMetadata(items) {
   });
 }
 
-function createScientistLinks(scientistIds, fallbackText) {
+function getFirstPublicationYear(scientist) {
+  return [...(scientist.publications || [])]
+    .filter((publication) => Number.isFinite(publication.year))
+    .sort((a, b) => a.year - b.year)[0]?.year;
+}
+
+function locateScientistOnTimeline(scientistId, scientist) {
+  closeModal({
+    restoreFocus: false,
+    afterClose: () => {
+      document.dispatchEvent(new CustomEvent('papertrails:locatescientist', {
+        detail: { scientistId, year: getFirstPublicationYear(scientist) }
+      }));
+    }
+  });
+}
+
+function createScientistLinks(scientistIds, fallbackText, linkTarget = 'profile') {
   const wrapper = document.createElement('span');
   wrapper.className = 'detail-scientist-links';
 
@@ -67,8 +84,13 @@ function createScientistLinks(scientistIds, fallbackText) {
     link.type = 'button';
     link.className = 'detail-scientist-link';
     link.textContent = scientist.name;
-    link.setAttribute('aria-label', `Open scientist profile for ${scientist.name}`);
-    link.addEventListener('click', () => showScientistModal(scientistId));
+    if (linkTarget === 'timeline') {
+      link.setAttribute('aria-label', `Locate ${scientist.name} on the timeline`);
+      link.addEventListener('click', () => locateScientistOnTimeline(scientistId, scientist));
+    } else {
+      link.setAttribute('aria-label', `Open scientist profile for ${scientist.name}`);
+      link.addEventListener('click', () => showScientistModal(scientistId));
+    }
     wrapper.appendChild(link);
   });
 
@@ -229,29 +251,27 @@ function createLocateAction(scientistId, scientist) {
   button.append(icon, label);
 
   button.addEventListener('click', () => {
-    const firstPublication = [...(scientist.publications || [])]
-      .filter((publication) => Number.isFinite(publication.year))
-      .sort((a, b) => a.year - b.year)[0];
-
-    closeModal({
-      restoreFocus: false,
-      afterClose: () => {
-        document.dispatchEvent(new CustomEvent('papertrails:locatescientist', {
-          detail: { scientistId, year: firstPublication?.year }
-        }));
-      }
-    });
+    locateScientistOnTimeline(scientistId, scientist);
   });
 
   return button;
 }
 
-export function showPublicationModal(actorName, itemYear, itemTitle, description, type = 'publication', scientistIds = []) {
+export function showPublicationModal(
+  actorName,
+  itemYear,
+  itemTitle,
+  description,
+  type = 'publication',
+  scientistIds = [],
+  attendeeIds = []
+) {
   if (!panel && !fetchElements()) return;
 
   const typeLabels = {
     publication: 'Publication',
     discovery: 'Scientific discovery',
+    conference: 'Scientific conference',
     event: 'Historical context'
   };
 
@@ -268,14 +288,23 @@ export function showPublicationModal(actorName, itemYear, itemTitle, description
   metadata.hidden = false;
 
   if (type === 'event') {
-    renderMetadata([['Period', itemYear]]);
+    const eventMetadata = [['Period', itemYear]];
+    if (Array.isArray(attendeeIds) && attendeeIds.length) {
+      eventMetadata.push(['Attendees', createScientistLinks(attendeeIds, '', 'timeline')]);
+    }
+    renderMetadata(eventMetadata);
   } else {
-    renderMetadata([
-      [type === 'discovery' ? 'Discoverer' : 'Author', type === 'discovery'
-        ? createScientistLinks(scientistIds, actorName)
-        : actorName],
-      ['Year', String(itemYear || 'Not recorded')]
-    ]);
+    const itemMetadata = [];
+    if (type === 'discovery') {
+      itemMetadata.push(['Discoverer', createScientistLinks(scientistIds, actorName)]);
+    } else if (type === 'publication') {
+      itemMetadata.push(['Author', actorName]);
+    }
+    if (Array.isArray(attendeeIds) && attendeeIds.length) {
+      itemMetadata.push(['Attendees', createScientistLinks(attendeeIds, '', 'timeline')]);
+    }
+    itemMetadata.push(['Year', String(itemYear || 'Not recorded')]);
+    renderMetadata(itemMetadata);
   }
 
   openPanel();

--- a/src/timelineRenderer.js
+++ b/src/timelineRenderer.js
@@ -1,6 +1,6 @@
 import { config } from './config.js?v=10';
 import { scientists, discoveries, significantEvents } from './dataLoader.js?v=10';
-import { showPublicationModal, showScientistModal } from './modalManager.js?v=10';
+import { showPublicationModal, showScientistModal } from './modalManager.js?v=12';
 import { handleImageError } from './themeManager.js?v=10';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -284,8 +284,9 @@ function renderDiscoveries(timeline, svg, width, axisY, contextTop) {
           discovery.year,
           discovery.title,
           discovery.details,
-          'discovery',
-          discovery.scientist_ids
+          discovery.type === 'conference' ? 'conference' : 'discovery',
+          discovery.scientist_ids,
+          discovery.attendee_ids
         );
       });
       timeline.appendChild(marker);
@@ -338,7 +339,15 @@ function renderEvents(timeline, width, height, contextTop) {
       band.appendChild(eventTitle);
       band.addEventListener('click', () => {
         selectItem(band);
-        showPublicationModal('Historical context', `${event.startYear}–${event.endYear}`, event.title, event.details, 'event');
+        showPublicationModal(
+          'Historical context',
+          `${event.startYear}–${event.endYear}`,
+          event.title,
+          event.details,
+          'event',
+          [],
+          event.attendee_ids
+        );
       });
       timeline.appendChild(band);
     });


### PR DESCRIPTION
## Summary

- Add conference milestones and attendee links to the timeline data.
- Allow event and conference detail cards to link attendees to their timeline positions.
- Update documentation and cache-busting versions.

## Testing

- Not run; no automated test suite was provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added six historical conference milestones to the timeline, spanning 1881–1957.
  - Conference entries now display types, descriptions, particles, colors, and attendee details.
  - Added links that can locate scientists on the timeline.
  - Publication and conference details now include related attendee information.

- **Documentation**
  - Updated dataset documentation with conference milestone fields and attendee references.

- **Bug Fixes**
  - Refreshed application assets to ensure the latest timeline and modal updates load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->