### PR TITLE
Link publication authors to scientist cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,6 @@
   <div class="timeline-tooltip" id="timeline-tooltip" role="tooltip" hidden></div>
 
   <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
-  <script type="module" src="script.js?v=14"></script>
+  <script type="module" src="script.js?v=15"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 import { config } from './src/config.js?v=14';
 import { initializeData } from './src/dataLoader.js?v=14';
 import { initializeTheme } from './src/themeManager.js?v=14';
-import { setupModalEventListeners } from './src/modalManager.js?v=14';
-import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=14';
+import { setupModalEventListeners } from './src/modalManager.js?v=15';
+import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=15';
 
 let timelineContainer;
 let timeline;

--- a/src/modalManager.js
+++ b/src/modalManager.js
@@ -222,7 +222,7 @@ function createAcademicAffiliations(scientist) {
   return section;
 }
 
-function createPublicationList(scientist) {
+function createPublicationList(scientistId, scientist) {
   const section = document.createElement('section');
   section.className = 'detail-publications';
 
@@ -277,7 +277,14 @@ function createPublicationList(scientist) {
 
       button.append(year, content, arrow);
       button.addEventListener('click', () => {
-        showPublicationModal(scientist.name, publication.year, publication.title, publication.abstract, 'publication');
+        showPublicationModal(
+          scientist.name,
+          publication.year,
+          publication.title,
+          publication.abstract,
+          'publication',
+          [scientistId]
+        );
       });
       item.appendChild(button);
       list.appendChild(item);
@@ -366,7 +373,7 @@ export function showPublicationModal(
     if (type === 'discovery') {
       itemMetadata.push(['Discoverer', createScientistLinks(scientistIds, actorName)]);
     } else if (type === 'publication') {
-      itemMetadata.push(['Author', actorName]);
+      itemMetadata.push(['Author', createScientistLinks(scientistIds, actorName)]);
     }
     if (Array.isArray(attendeeIds) && attendeeIds.length) {
       itemMetadata.push(['Attendees', createScientistLinks(attendeeIds, '', 'timeline')]);
@@ -395,7 +402,7 @@ export function showScientistModal(scientistId) {
 
   const academicAffiliations = createAcademicAffiliations(scientist);
   const locateAction = createLocateAction(scientistId, scientist);
-  body.replaceChildren(...[academicAffiliations, summary, createPublicationList(scientist), locateAction].filter(Boolean));
+  body.replaceChildren(...[academicAffiliations, summary, createPublicationList(scientistId, scientist), locateAction].filter(Boolean));
   image.src = scientist.photo || 'images/default.png';
   image.alt = scientist.name ? `Portrait of ${scientist.name}` : 'Scientist portrait';
   media.style.setProperty('--scientist-color', scientist.color || 'var(--accent)');

--- a/src/timelineRenderer.js
+++ b/src/timelineRenderer.js
@@ -1,6 +1,6 @@
 import { config } from './config.js?v=14';
 import { scientists, discoveries, significantEvents } from './dataLoader.js?v=14';
-import { showPublicationModal, showScientistModal } from './modalManager.js?v=14';
+import { showPublicationModal, showScientistModal } from './modalManager.js?v=15';
 import { handleImageError } from './themeManager.js?v=14';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -133,7 +133,14 @@ function renderPublications(timeline, width, axisY, coordinates) {
         marker.addEventListener('blur', () => unhighlightScientistGroup(scientistId));
         marker.addEventListener('click', () => {
           selectItem(marker);
-          showPublicationModal(scientist.name, publication.year, publication.title, publication.abstract, 'publication');
+          showPublicationModal(
+            scientist.name,
+            publication.year,
+            publication.title,
+            publication.abstract,
+            'publication',
+            [scientistId]
+          );
         });
         timeline.appendChild(marker);
       });


### PR DESCRIPTION
## Summary

- Link publication authors in detail and timeline modals to their scientist cards.
- Update publication metadata to use the shared scientist-link rendering.
- Refresh module cache versions and refine significant-event labels.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable scientist links to publication and discovery metadata, enabling direct navigation to scientist profiles.
  * Publication modals now retain the associated scientist context for improved navigation.

* **Bug Fixes**
  * Updated application resources to ensure the latest modal and timeline behavior loads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->