### PR TITLE
Fix publication markers rendering as circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Explore scientific publications, discoveries, and their historical context from 1400 to today.">
   <title>Paper Trails — Scientific History</title>
   <link rel="icon" href="images/icon.png" type="image/png">
-  <link rel="stylesheet" href="style.css?v=14">
+  <link rel="stylesheet" href="style.css?v=15">
 </head>
 <body>
   <header class="app-header">

--- a/style.css
+++ b/style.css
@@ -617,7 +617,7 @@ body.dark-mode .icon-sun {
   border-radius: 1px;
   background: var(--publication);
   box-shadow: 0 0 0 1px var(--border-strong);
-  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
+  rotate: 45deg;
   transition: background-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
 }
 


### PR DESCRIPTION
## Summary

- Render publication markers on the timeline as true diamonds by rotating the bordered marker square.
- Bump the stylesheet cache key so browsers load the corrected marker styling.

## Why

The legend correctly showed a diamond, but clipping the bordered timeline marker removed most of its outline and made it appear circular.

## Testing

- Visually verified publication markers at 100% and 450% timeline zoom in Chromium.
- Confirmed all 160 rendered publication markers use a 45-degree rotation with no clipping.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated historical coverage information to begin in 1400 instead of 1600.

* **Style**
  * Updated publication mark styling for improved shape rendering.

* **Chores**
  * Refreshed asset versions to ensure the latest styles and scripts load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->