### PR TITLE
Add scientist cartoon grids to detail modals

### DIFF
--- a/data/scientists.yaml
+++ b/data/scientists.yaml
@@ -1672,6 +1672,7 @@ kleist:
   summary: "A Prussian cleric and natural philosopher who independently invented an early electrical-storage device, a precursor of the Leyden jar and the modern capacitor."
   color: "#a47148"
   photo: "images/default.png"
+  cartoon: "images/cartoons/kleist.png"
   nationality: "Prussian"
   birth: "1700-06-10"
   death: "1748-12-11"

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="Explore scientific publications, discoveries, conferences, and their historical context from 1400 to today.">
   <title>Paper Trails — Scientific History</title>
   <link rel="icon" href="images/icon.png" type="image/png">
-  <link rel="stylesheet" href="style.css?v=16">
+  <link rel="stylesheet" href="style.css?v=17">
 </head>
 <body>
   <header class="app-header">
@@ -145,6 +145,6 @@
   <div class="timeline-tooltip" id="timeline-tooltip" role="tooltip" hidden></div>
 
   <script src="https://cdn.jsdelivr.net/npm/js-yaml/dist/js-yaml.min.js"></script>
-  <script type="module" src="script.js?v=16"></script>
+  <script type="module" src="script.js?v=17"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 import { config } from './src/config.js?v=14';
 import { initializeData } from './src/dataLoader.js?v=16';
 import { initializeTheme } from './src/themeManager.js?v=14';
-import { setupModalEventListeners } from './src/modalManager.js?v=16';
+import { setupModalEventListeners } from './src/modalManager.js?v=17';
 import { clearTimelineSelection, renderTimeline, updateEventLabelPositions } from './src/timelineRenderer.js?v=16';
 
 let timelineContainer;

--- a/src/modalManager.js
+++ b/src/modalManager.js
@@ -101,6 +101,89 @@ function createScientistLinks(scientistIds, fallbackText, linkTarget = 'profile'
   return wrapper;
 }
 
+function getScientistSurname(scientist) {
+  return String(scientist.name || '')
+    .replace(/[()]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .pop();
+}
+
+function createScientistGrid(scientistIds, headingText, countNoun) {
+  const seenScientistIds = new Set();
+  const linkedScientists = (Array.isArray(scientistIds) ? scientistIds : [])
+    .map((scientistId) => [scientistId, scientists[scientistId]])
+    .filter(([scientistId, scientist]) => {
+      if (!scientist || seenScientistIds.has(scientistId)) return false;
+      seenScientistIds.add(scientistId);
+      return true;
+    })
+    .sort(([, firstScientist], [, secondScientist]) => (
+      getScientistSurname(firstScientist).localeCompare(
+        getScientistSurname(secondScientist),
+        undefined,
+        { sensitivity: 'base' }
+      ) || String(firstScientist.name || '').localeCompare(
+        String(secondScientist.name || ''),
+        undefined,
+        { sensitivity: 'base' }
+      )
+    ));
+  if (!linkedScientists.length) return null;
+
+  const section = document.createElement('section');
+  section.className = 'detail-people';
+
+  const headingRow = document.createElement('div');
+  headingRow.className = 'detail-section-heading';
+
+  const heading = document.createElement('h3');
+  heading.textContent = headingText;
+
+  const count = document.createElement('span');
+  count.className = 'detail-section-count';
+  count.textContent = String(linkedScientists.length);
+  count.setAttribute(
+    'aria-label',
+    `${linkedScientists.length} ${countNoun}${linkedScientists.length === 1 ? '' : 's'}`
+  );
+  headingRow.append(heading, count);
+
+  const list = document.createElement('ul');
+  list.className = 'detail-person-grid';
+  linkedScientists.forEach(([scientistId, scientist]) => {
+    const item = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'detail-person-link';
+    button.setAttribute('aria-label', `Open scientist profile for ${scientist.name}`);
+
+    const portrait = document.createElement('img');
+    portrait.className = 'detail-person-portrait';
+    portrait.src = scientist.cartoon || scientist.photo || 'images/default.png';
+    portrait.alt = '';
+    portrait.decoding = 'async';
+    portrait.loading = 'lazy';
+    portrait.addEventListener('error', () => {
+      portrait.src = portrait.src.endsWith('/default.png')
+        ? portrait.src
+        : scientist.photo || 'images/default.png';
+    });
+
+    const name = document.createElement('span');
+    name.className = 'detail-person-name';
+    name.textContent = scientist.name;
+
+    button.append(portrait, name);
+    button.addEventListener('click', () => showScientistModal(scientistId));
+    item.appendChild(button);
+    list.appendChild(item);
+  });
+
+  section.append(headingRow, list);
+  return section;
+}
+
 function openPanel() {
   if (!panel || !backdrop) return;
 
@@ -360,6 +443,15 @@ export function showPublicationModal(
   descriptionText.className = 'detail-copy';
   descriptionText.textContent = description || 'No further details are available.';
   body.appendChild(descriptionText);
+  const peopleGrid = type === 'conference'
+    ? createScientistGrid(attendeeIds, 'Attendees', 'attendee')
+    : type === 'discovery'
+      ? createScientistGrid([
+        ...(Array.isArray(scientistIds) ? scientistIds : []),
+        ...(Array.isArray(theoristIds) ? theoristIds : [])
+      ], 'Scientists', 'scientist')
+      : null;
+  if (peopleGrid) body.appendChild(peopleGrid);
   media.hidden = true;
   metadata.hidden = false;
 
@@ -379,7 +471,7 @@ export function showPublicationModal(
     if (Array.isArray(theoristIds) && theoristIds.length) {
       itemMetadata.push(['Theorists', createScientistLinks(theoristIds, '')]);
     }
-    if (Array.isArray(attendeeIds) && attendeeIds.length) {
+    if (type !== 'conference' && Array.isArray(attendeeIds) && attendeeIds.length) {
       itemMetadata.push(['Attendees', createScientistLinks(attendeeIds, '', 'timeline')]);
     }
     itemMetadata.push(['Year', String(itemYear || 'Not recorded')]);

--- a/src/modalManager.js
+++ b/src/modalManager.js
@@ -165,9 +165,13 @@ function createScientistGrid(scientistIds, headingText, countNoun) {
     portrait.decoding = 'async';
     portrait.loading = 'lazy';
     portrait.addEventListener('error', () => {
-      portrait.src = portrait.src.endsWith('/default.png')
-        ? portrait.src
-        : scientist.photo || 'images/default.png';
+      if (portrait.src.endsWith('/default.png')) {
+        portrait.src = portrait.src;
+      } else if (scientist.photo && portrait.src !== scientist.photo) {
+        portrait.src = scientist.photo;
+      } else {
+        portrait.src = 'images/default.png';
+      }
     });
 
     const name = document.createElement('span');

--- a/style.css
+++ b/style.css
@@ -1176,6 +1176,76 @@ body.dark-mode .icon-sun {
   text-align: center;
 }
 
+.detail-people {
+  margin-top: 28px;
+  padding-top: 22px;
+  border-top: 1px solid var(--border);
+}
+
+.detail-person-grid {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(76px, 1fr));
+  gap: 14px 10px;
+  list-style: none;
+}
+
+.detail-person-link {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.detail-person-portrait {
+  width: 62px;
+  height: 62px;
+  display: block;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  background: var(--surface-muted);
+  object-fit: cover;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.detail-person-name {
+  max-width: 100%;
+  color: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: center;
+}
+
+.detail-person-link:hover {
+  color: var(--accent);
+}
+
+.detail-person-link:hover .detail-person-portrait {
+  border-color: var(--accent);
+  box-shadow: 0 3px 12px color-mix(in srgb, var(--accent) 22%, transparent);
+  transform: translateY(-2px);
+}
+
+.detail-person-link:focus-visible {
+  border-radius: 6px;
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.detail-person-link:focus-visible .detail-person-portrait {
+  border-color: var(--accent);
+}
+
 .detail-publication-list {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Summary

- Add sortable scientist grids to conference and discovery detail modals.
- Use cartoon portraits with photo/default fallbacks and accessible profile buttons.
- Add responsive grid styling and update asset cache versions.
- Add Ewald Georg von Kleist’s cartoon portrait metadata.

## Testing

- Not run (no test commands provided).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scientist portraits, including artwork for Kleist.
  - Added responsive, clickable people grids to discovery and conference details.
  - Displays linked scientists and theorists with portraits, names, counts, profile buttons, lazy loading, and fallback images.
  - Added surname sorting and duplicate removal for clearer listings.
  - Added keyboard focus and hover states for improved accessibility.

- **Bug Fixes**
  - Prevented conference attendees from appearing twice in detail views.
  - Updated asset versions to ensure the latest styling and functionality load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->