### PR TITLE
Add historical discoveries and U.S. Constitution event

### DIFF
--- a/data/discoveries.yaml
+++ b/data/discoveries.yaml
@@ -82,6 +82,13 @@
   particle: c
   color: "#ffcc00" # Golden Yellow
 
+- year: 1708
+  title: "Measurement of the Speed of Sound"
+  discoverer: "William Derham"
+  details: "Derham timed the delay between the visible flash and the report of distant gunfire from the tower of St Laurence Church in Upminster. Using surveyed distances, he obtained one of the earliest reasonably accurate measurements of the speed of sound in air."
+  particle: vₛ
+  color: "#52796f"
+
 - year: 1745
   title: "Invention of the Leyden Jar"
   discoverer: "Ewald Georg von Kleist"
@@ -89,6 +96,14 @@
   details: "Ewald Georg von Kleist invented the Leyden jar, the first capacitor, capable of storing electrical charge."
   particle: LJar
   color: "#8b0000" # Dark Red
+
+- year: 1758
+  title: "Return of Halley's Comet"
+  discoverer: "Johann Georg Palitzsch; return predicted by Edmond Halley"
+  theorist_ids: [newton]
+  details: "Palitzsch recovered the predicted comet on 25 December 1758; it reached perihelion in March 1759. Its return confirmed Halley's application of Newtonian gravitation to periodic cometary orbits."
+  particle: "☄"
+  color: "#6f4e7c"
 
 - year: 1848
   title: "Concept of Absolute Zero"

--- a/data/significantevents.yaml
+++ b/data/significantevents.yaml
@@ -105,6 +105,13 @@
   color: "#34495e"
   details: "The war of independence fought by the American colonies against Britain."
 
+- title: "Signing of the United States Constitution"
+  shortTitle: "U.S. Const."
+  startYear: 1787
+  endYear: 1787
+  color: "#3c6e71"
+  details: "On 17 September 1787, 39 delegates to the Constitutional Convention signed the proposed Constitution in Philadelphia, establishing a new framework for the United States government subject to ratification by the states."
+
 - title: "American Civil War"
   shortTitle: "ACW"
   startYear: 1861


### PR DESCRIPTION
## Summary

- Add historical discovery entries for the speed of sound measurement and Halley’s Comet return.
- Add the 1787 signing of the United States Constitution as a significant event.
- Remove the obsolete scientist-addition skill files.

## Testing

- Not run (data-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added historical discoveries covering the first measurement of the speed of sound and the return of Halley’s Comet.
  * Added a significant historical event for the signing of the United States Constitution in 1787.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->